### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ sensor:
         lambda: |-
           char text[30];
           sprintf(text,"Light: %2.1f lx", id(sensorlx).state);
-          id(rgb8x32)->add_screen_u("sun",  text ,5,false); // 5 Minutes, no alarm
+          id(rgb8x32)->add_screen("sun", text, 5, false); // 5 Minutes, no alarm
 ```
 
 Take care that the ```char text[30];``` has enough space to store the formated text. 
@@ -280,7 +280,7 @@ api:
         text: string
       then:
         lambda: |-
-          id(rgb8x32)->add_screen_u(icon_name,text,7,true); // 7 Minutes alarm=true
+          id(rgb8x32)->add_screen(icon_name, text, 7, true); // 7 Minutes alarm=true
 ```
 
 Service **_brightness**

--- a/components/ehmtx/EHMTX.cpp
+++ b/components/ehmtx/EHMTX.cpp
@@ -176,47 +176,17 @@ namespace esphome
     this->scroll_intervall = si;
   }
 
-  void EHMTX::del_screen_n(std::string iname)
+  void EHMTX::del_screen(std::string iname)
   {
     uint8_t icon = this->find_icon(iname.c_str());
-    this->del_screen(icon);
-  }
-
-  void EHMTX::del_screen(uint8_t icon)
-  {
     this->store->delete_screen(icon);
   }
 
-  void EHMTX::add_alarm(uint8_t icon, std::string text)
+  void EHMTX::add_screen(std::string iconname, std::string text, uint16_t duration, bool alarm)
   {
-    this->internal_add_screen(icon, text, this->duration, true);
-    ESP_LOGD(TAG, "add_alarm icon: %d text: %s", icon, text.c_str());
-  }
-
-  void EHMTX::add_screen(uint8_t icon, std::string text)
-  {
-    this->internal_add_screen(icon, text, this->duration, false);
-    ESP_LOGD(TAG, "add_screen icon: %d text: %s", icon, text.c_str());
-  }
-
-  void EHMTX::add_screen_u(std::string iname, std::string text, uint16_t duration, bool alarm)
-  {
-    uint8_t icon = this->find_icon(iname.c_str());
+    uint8_t icon = this->find_icon(iconname.c_str());
     this->internal_add_screen(icon, text, duration, alarm);
-    ESP_LOGD(TAG, "add_screen_u icon: %d iconname: %s text: %s duration: %d alarm: %d", icon, iname.c_str(), text.c_str(), duration, alarm);
-  }
-
-  void EHMTX::add_screen_n(std::string iname, std::string text)
-  {
-    uint8_t icon = this->find_icon(iname.c_str());
-    this->internal_add_screen(icon, text, this->duration, false);
-    ESP_LOGD(TAG, "add_screen_n icon: %d iconname: %s text: %s", icon, iname.c_str(), text.c_str());
-  }
-
-  void EHMTX::add_screen_t(uint8_t icon, std::string text, uint16_t t)
-  {
-    this->internal_add_screen(icon, text, t, false);
-    ESP_LOGD(TAG, "add_screen_t icon: %d duration: %d text: %s", icon, t, text.c_str());
+    ESP_LOGD(TAG, "add_screen icon: %d iconname: %s text: %s duration: %d alarm: %d", icon, iconname.c_str(), text.c_str(), duration, alarm);
   }
 
   void EHMTX::internal_add_screen(uint8_t icon, std::string text, uint16_t duration, bool alarm = false)

--- a/components/ehmtx/EHMTX.h
+++ b/components/ehmtx/EHMTX.h
@@ -150,8 +150,16 @@ namespace esphome
 
     void play(Ts... x) override
     {
-      this->parent_->add_screen(this->icon_.value(x...), this->text_.value(x...), this->duration_.value(x...),
-                                  this->alarm_.value(x...));
+      auto icon = this->icon_.value(x...);
+      auto text = this->text_.value(x...);
+      auto duration = this->duration_.value(x...);
+      auto alarm = this->alarm_.value(x...);
+
+      if(duration) {
+        this->parent_->add_screen(icon, text, duration, alarm);
+      } else {
+        this->parent_->add_screen(icon, text, this->parent_->duration, alarm);
+      }
     }
 
   protected:

--- a/components/ehmtx/EHMTX.h
+++ b/components/ehmtx/EHMTX.h
@@ -64,13 +64,8 @@ namespace esphome
     void set_default_brightness(uint8_t b);
     void set_brightness(uint8_t b);
     uint8_t get_brightness();
-    void add_alarm(uint8_t icon, std::string text);
-    void add_screen(uint8_t icon, std::string text);
-    void add_screen_n(std::string icon, std::string text);
-    void add_screen_u(std::string icon, std::string text, uint16_t duration, bool alarm);
-    void add_screen_t(uint8_t icon, std::string text, uint16_t t);
-    void del_screen(uint8_t icon);
-    void del_screen_n(std::string iname);
+    void add_screen(std::string icon, std::string text, uint16_t duration, bool alarm);
+    void del_screen(std::string iname);
     void set_clock(time::RealTimeClock *clock);
     void set_font(display::Font *font);
     void set_anim_intervall(uint16_t intervall);
@@ -155,7 +150,7 @@ namespace esphome
 
     void play(Ts... x) override
     {
-      this->parent_->add_screen_u(this->icon_.value(x...), this->text_.value(x...), this->duration_.value(x...),
+      this->parent_->add_screen(this->icon_.value(x...), this->text_.value(x...), this->duration_.value(x...),
                                   this->alarm_.value(x...));
     }
 
@@ -206,7 +201,7 @@ namespace esphome
 
     void play(Ts... x) override
     {
-      this->parent_->del_screen(this->parent_->find_icon(this->icon_.value(x...)));
+      this->parent_->del_screen(this->icon_.value(x...));
     }
 
   protected:

--- a/components/ehmtx/__init__.py
+++ b/components/ehmtx/__init__.py
@@ -92,14 +92,12 @@ ADD_SCREEN_ACTION_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.use_id(EHMTX_),
         cv.Required(CONF_ICON): cv.templatable(cv.string),
         cv.Required(CONF_TEXT): cv.templatable(cv.string),
-        cv.Optional(CONF_DURATION, default=5): cv.templatable(cv.positive_int),
+        cv.Optional(CONF_DURATION): cv.templatable(cv.positive_int),
         cv.Optional(CONF_ALARM, default=False): cv.templatable(cv.boolean),
     }
 )
 
-
 AddScreenAction = ehmtx_ns.class_("AddScreenAction", automation.Action)
-
 
 @automation.register_action(
     "ehmtx.add.screen", AddScreenAction, ADD_SCREEN_ACTION_SCHEMA
@@ -107,13 +105,17 @@ AddScreenAction = ehmtx_ns.class_("AddScreenAction", automation.Action)
 async def ehmtx_add_screen_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
+
     template_ = await cg.templatable(config[CONF_ICON], args, cg.std_string)
     cg.add(var.set_icon(template_))
 
     template_ = await cg.templatable(config[CONF_TEXT], args, cg.std_string)
     cg.add(var.set_text(template_))
-    template_ = await cg.templatable(config[CONF_DURATION], args, cg.uint8)
-    cg.add(var.set_duration(template_))
+
+    if CONF_DURATION in config:
+        template_ = await cg.templatable(config[CONF_DURATION], args, cg.uint8)
+        cg.add(var.set_duration(template_))
+
     template_ = await cg.templatable(config[CONF_ALARM], args, bool)
     cg.add(var.set_alarm(template_))
     return var

--- a/ehmtx32.yaml
+++ b/ehmtx32.yaml
@@ -36,7 +36,7 @@ api:
         text: string
       then:
         lambda: |-
-          id(rgb8x32)->add_screen_u(icon_name,text,7,true);
+          id(rgb8x32)->add_screen(icon_name, text, 7, true);
           id(rgb8x32)->force_screen(icon_name);
     - service: screen
       variables:
@@ -44,7 +44,7 @@ api:
         text: string
       then:
         lambda: |-
-          id(rgb8x32)->add_screen_u(icon_name,text,5,false);
+          id(rgb8x32)->add_screen(icon_name, text, 5, false);
     - service: brightness
       variables:
         brightness: int
@@ -60,7 +60,7 @@ api:
         icon_name: string
       then:
         lambda: |-
-          id(rgb8x32)->del_screen_n(icon_name);
+          id(rgb8x32)->del_screen(icon_name);
     - service: indicator_on
       variables:
         r: int


### PR DESCRIPTION
* Small clean-up of old add_screen methods
* Use configured default value for duration of ehmtx.add.screen. There is a configuration value for this, but at the moment you always use 5.
```yaml
ehmtx:
   duration: 7
```
