### PR TITLE
Add Display On/Off Switch and Service Calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ components/ehmtx/EHMTX_icons._cpp
 ehmtx8266-select.yaml
 svganimtest.html
 servicetest
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -555,6 +555,28 @@ Service **indicator_off**
 
 removes the indicator
 
+Service **display_on** / **display_off**
+
+turns the display on or off
+
+There's an easier way in using a switch component:
+
+```
+switch:
+  - platform: template
+    name: "$devicename Display"
+    icon: "mdi:power"
+    restore_mode: ALWAYS_ON
+    lambda: |-
+      return id(rgb8x32)->show_display;
+    turn_on_action:
+      lambda: |-
+        id(rgb8x32)->set_display_on();
+    turn_off_action:
+      lambda: |-
+        id(rgb8x32)->set_display_off();
+```
+
 Service **skip**
 
 skips to the next screen
@@ -622,6 +644,24 @@ number:
     set_action:
       lambda: |-
         id(rgb8x32)->set_brightness(x);
+```
+
+#### display switch
+
+```
+switch:
+  - platform: template
+    name: "$devicename Display"
+    icon: "mdi:power"
+    restore_mode: ALWAYS_ON
+    lambda: |-
+      return id(rgb8x32)->show_display;
+    turn_on_action:
+      lambda: |-
+        id(rgb8x32)->set_display_on();
+    turn_off_action:
+      lambda: |-
+        id(rgb8x32)->set_display_off();
 ```
 
 #### force screen

--- a/UlanziTC001.yaml
+++ b/UlanziTC001.yaml
@@ -143,7 +143,15 @@ api:
       then:
         - ehmtx.indicator.off:
             id: rgb8x32
-
+    - service: display_on
+      then:
+        - ehmtx.display.on:
+            id: rgb8x32
+    - service: display_off
+      then:
+        - ehmtx.display.off:
+            id: rgb8x32
+            
 number:
   - platform: template
     name: "$devicename brightness"
@@ -155,6 +163,20 @@ number:
     set_action:
       lambda: |-
         id(rgb8x32)->set_brightness(x);
+
+switch:
+  - platform: template
+    name: "$devicename Display"
+    icon: "mdi:power"
+    restore_mode: ALWAYS_ON
+    lambda: |-
+      return id(rgb8x32)->show_display;
+    turn_on_action:
+      lambda: |-
+        id(rgb8x32)->set_display_on();
+    turn_off_action:
+      lambda: |-
+        id(rgb8x32)->set_display_off();
 
 sensor:
   - platform: sht3xd

--- a/UlanziTC001.yaml
+++ b/UlanziTC001.yaml
@@ -3,7 +3,7 @@ substitutions:
   ledpin: GPIO32 
   buzzerpin: GPIO15
   # Pin definition from https://github.com/aptonline/PixelIt_Ulanzi 
-  batt_pin: GPIO36 
+  batt_pin: GPIO34 
   ldr_pin: GPIO35 
   matrix_pin: GPIO32 
   left_button_pin: GPIO26 

--- a/components/ehmtx/EHMTX.cpp
+++ b/components/ehmtx/EHMTX.cpp
@@ -111,6 +111,18 @@ namespace esphome
     ESP_LOGD(TAG, "indicator on");
   }
 
+  void EHMTX::set_display_off()
+  {
+    this->show_display = false;
+    ESP_LOGD(TAG, "display off");
+  }
+
+  void EHMTX::set_display_on()
+  {
+    this->show_display = true;
+    ESP_LOGD(TAG, "display on");
+  }
+
   void EHMTX::set_gauge_off()
   {
     this->show_gauge = false;
@@ -250,6 +262,14 @@ namespace esphome
     else
     {
       ESP_LOGI(TAG, "status indicator off");
+    }
+    if (this->show_display)
+    {
+      ESP_LOGI(TAG, "status display on");
+    }
+    else
+    {
+      ESP_LOGI(TAG, "status display off");
     }
 
     this->store->log_status();
@@ -467,28 +487,30 @@ namespace esphome
 
   void EHMTX::draw()
   {
-    if (this->show_icons)
-    {
-      this->icon_screen->draw();
-    }
-    else
-    {
-      if (this->show_screen)
+    if (this->show_display) {
+      if (this->show_icons)
       {
-        this->store->current()->draw();
+        this->icon_screen->draw();
       }
       else
       {
-        this->draw_clock();
+        if (this->show_screen)
+        {
+          this->store->current()->draw();
+        }
+        else
+        {
+          this->draw_clock();
+        }
       }
-    }
 
-    if (this->show_indicator)
-    {
-      this->display->line(31, 5, 29, 7, this->indicator_color);
-      this->display->draw_pixel_at(30, 7, this->indicator_color);
-      this->display->draw_pixel_at(31, 6, this->indicator_color);
-      this->display->draw_pixel_at(31, 7, this->indicator_color);
+      if (this->show_indicator)
+      {
+        this->display->line(31, 5, 29, 7, this->indicator_color);
+        this->display->draw_pixel_at(30, 7, this->indicator_color);
+        this->display->draw_pixel_at(31, 6, this->indicator_color);
+        this->display->draw_pixel_at(31, 7, this->indicator_color);
+      }
     }
   }
 

--- a/components/ehmtx/EHMTX.h
+++ b/components/ehmtx/EHMTX.h
@@ -50,6 +50,7 @@ namespace esphome
     EHMTX_Icon *icons[MAXICONS];
     EHMTX_screen *icon_screen;
     void add_icon(EHMTX_Icon *icon);
+    bool show_display;
 #ifdef USE_EHMTX_SELECT
     std::vector<std::string> select_options;
     esphome::EhmtxSelect *select;
@@ -112,6 +113,8 @@ namespace esphome
     void add_on_next_screen_trigger(EHMTXNextScreenTrigger *t) { this->on_next_screen_triggers_.push_back(t); }
     void setup();
     void update();
+    void set_display_on();
+    void set_display_off();
   };
 
   class EHMTX_store
@@ -367,6 +370,36 @@ namespace esphome
     void play(Ts... x) override
     {
       this->parent_->set_indicator_off();
+    }
+
+  protected:
+    EHMTX *parent_;
+  };
+
+   template <typename... Ts>
+  class SetDisplayOn : public Action<Ts...>
+  {
+  public:
+    SetDisplayOn(EHMTX *parent) : parent_(parent) {}
+
+    void play(Ts... x) override
+    {
+      this->parent_->set_display_on();
+    }
+
+  protected:
+    EHMTX *parent_;
+  };
+
+   template <typename... Ts>
+  class SetDisplayOff : public Action<Ts...>
+  {
+  public:
+    SetDisplayOff(EHMTX *parent) : parent_(parent) {}
+
+    void play(Ts... x) override
+    {
+      this->parent_->set_display_off();
     }
 
   protected:

--- a/components/ehmtx/__init__.py
+++ b/components/ehmtx/__init__.py
@@ -405,6 +405,39 @@ async def ehmtx_set_indicator_off_action_to_code(config, action_id, template_arg
 
     return var
 
+SetDisplayOnAction = ehmtx_ns.class_("SetDisplayOn", automation.Action)
+
+DISPLAY_ON_ACTION_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.use_id(EHMTX_),
+    }
+)
+
+@automation.register_action(
+    "ehmtx.display.on", SetDisplayOnAction, DISPLAY_ON_ACTION_SCHEMA
+)
+async def ehmtx_set_display_on_action_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+
+    return var
+
+SetDisplayOffAction = ehmtx_ns.class_("SetDisplayOff", automation.Action)
+
+DISPLAY_OFF_ACTION_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.use_id(EHMTX_),
+    }
+)
+@automation.register_action(
+    "ehmtx.display.off", SetDisplayOffAction, DISPLAY_OFF_ACTION_SCHEMA
+)
+async def ehmtx_set_display_off_action_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+
+    return var
+
 CODEOWNERS = ["@lubeda"]
 
 async def to_code(config):

--- a/ehmtx32.yaml
+++ b/ehmtx32.yaml
@@ -90,6 +90,14 @@ api:
       then:
         lambda: |-
           id(rgb8x32)->set_indicator_off();
+    - service: display_on
+      then:
+        - ehmtx.display.on:
+            id: rgb8x32
+    - service: display_off
+      then:
+        - ehmtx.display.off:
+            id: rgb8x32
 
 ota:
   password: !secret ota_password
@@ -131,7 +139,21 @@ number:
     set_action:
       lambda: |-
         id(rgb8x32)->set_brightness(x);
-        
+
+switch:
+  - platform: template
+    name: "$devicename Display"
+    icon: "mdi:power"
+    restore_mode: ALWAYS_ON
+    lambda: |-
+      return id(rgb8x32)->show_display;
+    turn_on_action:
+      lambda: |-
+        id(rgb8x32)->set_display_on();
+    turn_off_action:
+      lambda: |-
+        id(rgb8x32)->set_display_off();
+                
 time:
   - platform: homeassistant
     id: ehmtx_time

--- a/ehmtx8266-color.yaml
+++ b/ehmtx8266-color.yaml
@@ -141,6 +141,14 @@ api:
       then:
         - ehmtx.indicator.off:
             id: rgb8x32
+    - service: display_on
+      then:
+        - ehmtx.display.on:
+            id: rgb8x32
+    - service: display_off
+      then:
+        - ehmtx.display.off:
+            id: rgb8x32
 
 ota:
   password: !secret ota_password
@@ -183,6 +191,20 @@ number:
       lambda: |-
         id(rgb8x32)->set_brightness(x);
 
+switch:
+  - platform: template
+    name: "$devicename Display"
+    icon: "mdi:power"
+    restore_mode: ALWAYS_ON
+    lambda: |-
+      return id(rgb8x32)->show_display;
+    turn_on_action:
+      lambda: |-
+        id(rgb8x32)->set_display_on();
+    turn_off_action:
+      lambda: |-
+        id(rgb8x32)->set_display_off();
+        
 time:
   - platform: homeassistant
     id: ehmtx_time

--- a/ehmtx8266-select.yaml
+++ b/ehmtx8266-select.yaml
@@ -108,6 +108,14 @@ api:
       then:
         - ehmtx.indicator.off:
             id: rgb8x32
+    - service: display_on
+      then:
+        - ehmtx.display.on:
+            id: rgb8x32
+    - service: display_off
+      then:
+        - ehmtx.display.off:
+            id: rgb8x32
 
 number:
   - platform: template
@@ -121,6 +129,20 @@ number:
       lambda: |-
         id(rgb8x32)->set_brightness(x);
 
+switch:
+  - platform: template
+    name: "$devicename Display"
+    icon: "mdi:power"
+    restore_mode: ALWAYS_ON
+    lambda: |-
+      return id(rgb8x32)->show_display;
+    turn_on_action:
+      lambda: |-
+        id(rgb8x32)->set_display_on();
+    turn_off_action:
+      lambda: |-
+        id(rgb8x32)->set_display_off();
+        
 ota:
   password: !secret ota_password
 

--- a/fullfeaturetest.yaml
+++ b/fullfeaturetest.yaml
@@ -230,6 +230,16 @@ api:
         - ehmtx.indicator.off:
             id: rgb8x32
 
+    - service: display_on
+      then:
+        - ehmtx.display.on:
+            id: rgb8x32
+            
+    - service: display_off
+      then:
+        - ehmtx.display.off:
+            id: rgb8x32
+
 number:
   - platform: template
     name: "$devicename brightness"
@@ -241,6 +251,20 @@ number:
     set_action:
       lambda: |-
         id(rgb8x32)->set_brightness(x);
+
+switch:
+  - platform: template
+    name: "$devicename Display"
+    icon: "mdi:power"
+    restore_mode: ALWAYS_ON
+    lambda: |-
+      return id(rgb8x32)->show_display;
+    turn_on_action:
+      lambda: |-
+        id(rgb8x32)->set_display_on();
+    turn_off_action:
+      lambda: |-
+        id(rgb8x32)->set_display_off();
 
 ota:
   password: !secret ota_password


### PR DESCRIPTION
I have added a Display switch and service calls to allow the display to be "powered" on/off from Home Assistant for when you do not want the display on.
This switch just stops the display updating rather than truly powering it off.

All example yaml files and documentation has been updated to detail this.