### PR TITLE
Add option for wildcard's on icon name for del_screen function

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,8 +524,12 @@ Service **del_screen**
 
 Removes a screen from the display by icon name. If this screen is actually display while sending this command the screen will be displayed until its "show_screen"-time has ended.
 
+Optionally you can suffix a * to the icon name to perform a wildcard delete which will delete all screens beginning with the icon_name specified.
+
+For example if you have multiple icons named weather_sunny, weather_rain & weather_cloudy, you can issue a del_screen weather_* to remove whichever screen is currently in a slot and replace it with a new weather screen.
+
 parameters:
-- ```icon_name``` The name of the icons as in the yaml (see installation)
+- ```icon_name``` The name of the icon as in the yaml (see installation)
 
 Service **indicator_on**
 

--- a/components/ehmtx/EHMTX.cpp
+++ b/components/ehmtx/EHMTX.cpp
@@ -85,6 +85,15 @@ namespace esphome
     ESP_LOGD(TAG, "text color r: %d g: %d b: %d", r, g, b);
   }
 
+  bool EHMTX::string_has_ending(std::string const &fullString, std::string const &ending) 
+  {
+      if (fullString.length() >= ending.length()) {
+          return (0 == fullString.compare (fullString.length() - ending.length(), ending.length(), ending));
+      } else {
+          return false;
+      }
+  }
+
   uint8_t EHMTX::find_icon(std::string name)
   {
     for (uint8_t i = 0; i < this->icon_count; i++)
@@ -300,8 +309,25 @@ namespace esphome
 
   void EHMTX::del_screen(std::string iname)
   {
-    uint8_t icon = this->find_icon(iname.c_str());
-    this->store->delete_screen(icon);
+    // if has ending of *
+    if (this->string_has_ending(iname, "*")) {
+      // remove the *
+      std::string comparename = iname.substr(0, iname.length()-1);
+
+      // iterate through the icons, comparing start only
+      for (uint8_t i = 0; i < this->icon_count; i++)
+      {`
+        std::string iconname = this->icons[i]->name.c_str();
+        if (iconname.rfind(comparename, 0) == 0)
+        {
+          this->store->delete_screen(i);
+        }
+      }
+    }
+    else {
+      uint8_t icon = this->find_icon(iname.c_str());
+      this->store->delete_screen(icon);
+    }
   }
 
   void EHMTX::add_screen(std::string iconname, std::string text, uint16_t duration, bool alarm)

--- a/components/ehmtx/EHMTX.h
+++ b/components/ehmtx/EHMTX.h
@@ -61,6 +61,7 @@ namespace esphome
     display::Font *font;
     int8_t yoffset, xoffset;
     uint8_t find_icon(std::string name);
+    bool string_has_ending(std::string const &fullString, std::string const &ending);
     uint16_t duration;         // in minutes how long is a screen valid
     uint16_t scroll_intervall; // ms to between scrollsteps
     uint16_t anim_intervall;   // ms to next_frame()


### PR DESCRIPTION
Optionally you can suffix a * to the icon name to perform a wildcard delete which will delete all screens beginning with the icon_name specified.

For example if you have multiple icons named weather_sunny, weather_rain & weather_cloudy, you can issue a del_screen weather_* to remove whichever screen is currently in a slot and replace it with a new weather screen.
