### PR TITLE
Adding auto-adjust brightness

### DIFF
--- a/UlanziTC001.yaml
+++ b/UlanziTC001.yaml
@@ -37,6 +37,22 @@ font:
     glyphs:  |
       !?"%()+*=,-_.:°0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnÖÄÜöäüopqrstuvwxyz€@<>/
 
+globals:
+  # aab = auto-adjustable brightness
+  - id: aab_enable
+    type: "bool"
+    restore_value: true
+    initial_value: "true"
+  - id: aab_add
+    type: int
+    initial_value: '10'
+  - id: aab_max
+    type: int
+    initial_value: '220'
+  - id: aab_min
+    type: int
+    initial_value: '20'
+
 binary_sensor:
   - platform: status
     name: "$devicename Status"
@@ -107,6 +123,24 @@ switch:
     turn_off_action:
       lambda: |-
         id(rgb8x32)->set_display_off();
+  - platform: template
+    name: "Auto-Adjust Brightness"
+    id: switch_autobrightness
+    icon: mdi:brightness-auto
+    restore_mode: RESTORE_DEFAULT_ON
+    lambda: |-
+      if (id(aab_enable)) {
+        return true;
+      } else {
+        return false;
+      }
+    turn_on_action:
+      lambda: |-
+        id(aab_enable) = true;
+    turn_off_action:
+      lambda: |-
+        id(aab_enable) = false;
+
 
 sensor:
   - platform: sht3xd
@@ -147,6 +181,17 @@ sensor:
     filters:
       - lambda: |-
           return (x / 10000.0) * 2000000.0 - 15 ;
+    on_value:
+      then:
+        - lambda: |-
+            if ( id(aab_enable) ) {
+              int n = x / 4 + id(aab_add); // new_value
+              if (n > id(aab_max)) n = id(aab_max);
+              if (n < id(aab_min)) n = id(aab_min);
+              int c = id(rgb8x32)->get_brightness(); // current value
+              int d = (n - c) * 100 / c; // diff in %
+              if ( abs(d) > 2 ) id(rgb8x32)->set_brightness(n);
+            }
 
 ota:
   password: !secret ota_password


### PR DESCRIPTION
This adds auto-adjustable brightness.

State (on/off) is stored in a global variable. There's a switch to enable/disable the function from HA.

Brightness is calculated from the ambient light sensor. Looking at the [illuminance-table at
wikipedia](https://en.wikipedia.org/wiki/Lux#Illuminance), it seems reasonable to divide ambient light by 4 and add a bit, so the algorithm I've used is: `x / 4 * 1.1`. Also, to avoid setting a new brightness every 10 seconds, we only adjust brightness if it is off by more than 2%.